### PR TITLE
[Fix] Bad output

### DIFF
--- a/includes/dkpdfg-functions.php
+++ b/includes/dkpdfg-functions.php
@@ -183,6 +183,8 @@ function dkpdfg_output_pdf() {
 		$mpdf->Output( 'dk-pdf-generator.pdf', 'D' );
 
 	}
+
+	die;
 }
 
 /**


### PR DESCRIPTION
Hello,

In some very specific environments (almost impossible to reproduce), dkpdfg_output_pdf() creates a second PDF with unpredictable results. Adding `die;` at the end forces dkpdfg to stop after rendering the first PDF and fixes the problem.

By the way, thanks for making this plugin available for everyone. I'm using it since 2018 (bought on Envato) and it's still awesome !

Cheers